### PR TITLE
Update Syntax paper to match 25-165r1

### DIFF
--- a/drafts/draft-syntax.txt
+++ b/drafts/draft-syntax.txt
@@ -58,38 +58,21 @@ C6. Assuming that edits for both work items DIN1 and US04 are applied for
     immediately precede the new optional COMPLETION argument in the syntax
     of each collective subroutine listed above.
 
-4. Completion Wait Statement Syntax
+4. Completion Query Function Syntax
 -----------------------------------
 
-A new <action-stmt> called COMPLETION WAIT is introduced, with the
+A new standard intrinsic subroutine called COMPLETE is introduced, with the
 following syntax:
 
-W1. <completion-wait-stmt>  <<is>>
-      COMPLETION WAIT ( <completion-item> )
+W1. COMPLETE( COMPLETION_VAR [, QUERY ]) 
 
-W2. <completion-item>  <<is>>  <variable>
+W2. COMPLETION_VAR   shall be a variable of type COMPLETION_TYPE from the
+                     intrinsic module ISO_FORTRAN_ENV. It shall not be
+                     coindexed. It is an INTENT(INOUT) argument.
 
-W3. The <completion-item> specifier to COMPLETION WAIT shall be a variable
-    of type COMPLETION_TYPE from the intrinsic module ISO_FORTRAN_ENV.
-
-W4. The COMPLETION WAIT statement contains no specifiers other than the
-    <completion-item>.
-
-See J3/25-165r1 for detailed specifications and semantics.
-
-5. Completion Query Function Syntax
------------------------------------
-
-A new standard intrinsic elemental function called COMPLETION_QUERY is
-introduced, with the following syntax:
-
-Q1. COMPLETION_QUERY ( COMPLETION )
-
-Q1. The COMPLETION argument to COMPLETION_QUERY() shall be a variable of
-    type COMPLETION_TYPE from the intrinsic module ISO_FORTRAN_ENV.
-
-Q3. The COMPLETION_QUERY function accepts no arguments other than the
-    completion variable.
+W3. QUERY (optional) when present, shall be a variable of logical type with
+                     the same shape as COMPLETION_VAR. It is an INTENT(OUT)
+                     argument.
 
 See J3/25-165r1 for detailed specifications and semantics.
 

--- a/drafts/draft-syntax.txt
+++ b/drafts/draft-syntax.txt
@@ -2,17 +2,17 @@ To: J3                                                     J3/25-166
 Subject: US04: Syntax for Asynchronous Collective Subroutines
 From: Brandon Cook & Damian Rouson & Dan Bonachea & Reuben D. Budiardja
 Date: 2025-September-12
-References: J3/25-162r1, J3/25-165, J3/25-127r1, WG5/N2249
+References: J3/25-162r2, J3/25-165r1, J3/25-127r1, WG5/N2249
 
 1. Background
 -------------
 The current Fortran 202Y work list WG5/N2249 includes asynchronous
 collective subroutines as accepted work item US04.
 
-Paper J3/25-162r1 "US04: Requirements for Asynchronous Collective
+Paper J3/25-162r2 "US04: Requirements for Asynchronous Collective
 Subroutines" presents an illustrative use case and a list of requirements.
 
-Paper J3/25-165 "US04: Specifications for Asynchronous Collective
+Paper J3/25-165r1 "US04: Specifications for Asynchronous Collective
 Subroutines" presents the proposed specifications and semantics for the new
 asynchronous collective subroutines feature. Please consult that paper for
 all semantic details, which will not be replicated here.
@@ -26,7 +26,7 @@ for the asynchronous collective subroutines feature.
 T1. New type COMPLETION_TYPE is added to the ISO_FORTRAN_ENV intrinsic
     module.
 
-See J3/25-165 for detailed specifications and semantics.
+See J3/25-165r1 for detailed specifications and semantics.
 
 3. Asynchronous Collective Initiation Syntax
 --------------------------------------------
@@ -45,7 +45,7 @@ C4. CO_REDUCE (A, OPERATION [, RESULT_IMAGE, STAT, ERRMSG, COMPLETION])
 
 C5. CO_SUM (A [, RESULT_IMAGE, STAT, ERRMSG, COMPLETION])
 
-See J3/25-165 for detailed specifications and semantics.
+See J3/25-165r1 for detailed specifications and semantics.
 
 Note that J3/25-127r1 "DIN1: Collectives over a specified team,
 req/spec/syntax/edits" also adds a different trailing optional argument
@@ -75,7 +75,7 @@ W3. The <completion-item> specifier to COMPLETION WAIT shall be a variable
 W4. The COMPLETION WAIT statement contains no specifiers other than the
     <completion-item>.
 
-See J3/25-165 for detailed specifications and semantics.
+See J3/25-165r1 for detailed specifications and semantics.
 
 5. Completion Query Function Syntax
 -----------------------------------
@@ -91,6 +91,6 @@ Q1. The COMPLETION argument to COMPLETION_QUERY() shall be a variable of
 Q3. The COMPLETION_QUERY function accepts no arguments other than the
     completion variable.
 
-See J3/25-165 for detailed specifications and semantics.
+See J3/25-165r1 for detailed specifications and semantics.
 
 ===END===


### PR DESCRIPTION
I'd like to have this syntax paper "ready-to-go" when the specs paper passes.